### PR TITLE
adding ability to allow extra columns to "tags" and "taggings tables via TABLE_SCHEMA_CHECK_ALLOW_EXTRA_COLUMNS environment variable

### DIFF
--- a/lib/redmine_acts_as_taggable_on/migration.rb
+++ b/lib/redmine_acts_as_taggable_on/migration.rb
@@ -99,7 +99,6 @@ class RedmineActsAsTaggableOn::Migration < ActsAsTaggableOnMigration
 
   def expected_tags_structure
     [
-      ['color', 'integer'],
       ['name', 'string'],
     ]
   end


### PR DESCRIPTION
tested this against redmine 2.3 with redmine_contacts 3.2.4 - migrating up and down with or without the environment variable works. you'll want to confirm using your build manager (travis, as i understand it)
